### PR TITLE
Moved image aspect calculation

### DIFF
--- a/js/jquery-imagefill.js
+++ b/js/jquery-imagefill.js
@@ -57,6 +57,7 @@
     function fitImages() {
 
       $container.each(function() {
+        imageAspect = $(this).find('img').width() / $(this).find('img').height();
         var containerW = $(this).width();
         var containerH = $(this).height();
         var containerAspect = containerW/containerH;


### PR DESCRIPTION
The image aspect should be calculated for each image itself because
within a page there can be multiple images with diferent aspect ratio's
that have to filled/centered.
