### PR TITLE
Change imagesLoaded to always execute.

### DIFF
--- a/js/jquery-imagefill.js
+++ b/js/jquery-imagefill.js
@@ -47,7 +47,7 @@
     });
 
     // wait for image to load, then fit it inside the container
-    $container.imagesLoaded().done(function(img) {
+    $container.imagesLoaded().always(function(img) {
       imageAspect = $img.width() / $img.height();
       $img.removeClass('loading');
       fitImages();


### PR DESCRIPTION
Fixes the issue if an image fails to load, none get filled.

See https://github.com/johnpolacek/imagefill.js/issues/21